### PR TITLE
Refactored Serial comms into state machine and handled a few extra error cases

### DIFF
--- a/vmstep/Settings.cpp
+++ b/vmstep/Settings.cpp
@@ -1,12 +1,6 @@
 #include "Settings.h"
 
 bool validate_settings(const Settings_union& settings) {
-    // clang-format off
-    if (settings.data.step_current > SettingLimits::MAX_CURRENT || 
-        settings.data.sleep_current > SettingLimits::MAX_CURRENT || 
-        settings.data.microstep_res > SettingLimits::MAX_MICROSTEP_RES) {
-        return false;
-    }
-    // clang-format on
+    // Nothing to validate yet
     return true;
 }

--- a/vmstep/Settings.h
+++ b/vmstep/Settings.h
@@ -3,17 +3,12 @@
 
 #include <Arduino.h>
 
-struct SettingLimits {
-    static constexpr uint8_t MAX_CURRENT = 0b1111;        // 4 bits
-    static constexpr uint8_t MAX_MICROSTEP_RES = 0b1111;  // 4 bits
-};
-
 struct __attribute__((packed)) Settings_struct {
     //motor control (4 bits each)
     uint8_t step_current: 4;      // max 0b1111
     uint8_t sleep_current: 4;     // max 0b1111
     uint8_t microstep_res: 4;     // max 0b1111
-    uint8_t reserved: 4;     // padding for algiment
+    uint8_t reserved: 4;     // padding for alignment
     uint8_t sleep_timeout;         // 10s of ms
     
     //trajectory (32 bits each)

--- a/vmstep/vmstep.ino
+++ b/vmstep/vmstep.ino
@@ -379,11 +379,7 @@ void homing() {
 }
 
 void loop() {
-    Comms.run();
-    if (Comms.new_data) {
-        process_message(Comms.recv_data, Comms.data_length);
-        Comms.new_data = false;
-    }
+    Comms.run(process_message);
 
     check_sensors();
 


### PR DESCRIPTION
_big brother asks for code review, little brother refactors everything :P_

## Summary

- Consolidated a bunch of the Serial state machine logic into a single enum. Documented the transitions.
  - I made it skip messages with empty payloads, not sure if that's what you wanted.
- Using a callback that only gives the user access to the byte array for a short duration. This discourages people from reading it while it's invalid/partial. Also made the member variables private to further discourage this.
- Consolidated `send()` implementations into a single function that the overloads call into. I find this pattern survives longer, and makes it easier to debug. It keeps the overloads "thin" and they can't diverge too much from each other.
  - Added input sanitization for null array
  - Avoid copying the `String` contents into a C-array by using `.c_str()` to get a pointer to the contents.
  - Up to you what you want to 
- Removed settings validity checking that didn't do anything. It was checking for a max value of `0b1111` but the size of the bitfield was only 4-bits anyways. C++ will simply truncate the bits if you try to assign a larger int type to this smaller one, so it's actually impossible to store larger than 0b1111 in this location. I've left the validity check function behind because I like the practice of explicit fault handling you've setup around it, and you should feel free to toss more checks into here as you change things.

## Testing
- [x] yolo
- [x] I have no idea if it compiles
- [x] merry xmas!